### PR TITLE
Applicative-style combinators for properties

### DIFF
--- a/src/Check.elm
+++ b/src/Check.elm
@@ -259,7 +259,7 @@ toResult : String -> IntermediateProperty Bool -> TestResult
 toResult name ip =
   let rec =
         { name = name
-        , value = ip.revArguments |> reverse |> toString
+        , value = ip.revArguments |> reverse |> join ", "
         , seed = ip.seed
         }
   in if ip.unappliedRest then Ok rec else Err rec

--- a/src/Check.elm
+++ b/src/Check.elm
@@ -110,11 +110,6 @@ mergeTestOutputs output1 output2 =
           mergeTestResults x y :: mergeTestOutputs xs ys
 
 
-generateTestCases : Generator (List a) -> Seed -> (List a, Seed)
-generateTestCases listGenerator seed =
-  generate listGenerator seed
-
-
 {-| Create a property given a number of test cases, a name, a condition to test and a generator
 Example :
 

--- a/src/Check.elm
+++ b/src/Check.elm
@@ -12,6 +12,9 @@ module Check
   , property3N
   , property4N
   , property5N
+  , describedBy
+  , on
+  , sample
   , check
   , simpleCheck
   , continuousCheck
@@ -52,8 +55,7 @@ import Graphics.Element (Element)
 import Text (leftAligned, monospace, fromString)
 
 type alias TestResult =
-  { name : String
-  , failed : Bool
+  { failed : Bool
   , value : String
   , seed : Seed
   }
@@ -247,12 +249,11 @@ defaultNumberOfSamples = 100
 
 {-| The `PartiallyAppliedPredicate` is now fully applied, so we expect `unappliedRest` to evaluate to
 a boolean, indicating whether this particular test succeeded.
-We take name, value and seed directly from the `PartiallyAppliedPredicate`.
+We take value and seed directly from the `PartiallyAppliedPredicate`.
 -}
-toResult : String -> PartiallyAppliedPredicate Bool -> TestResult
-toResult name ip = 
-  { name = name
-  , failed = not (ip.unappliedRest)
+toResult : PartiallyAppliedPredicate Bool -> TestResult
+toResult ip = 
+  { failed = not (ip.unappliedRest)
   , value = ip.revArguments |> reverse |> join ", "
   , seed = ip.seed
   }
@@ -261,7 +262,7 @@ propertyResults : Property -> Generator (List TestResult)
 propertyResults p = 
   list -- generate p.requestedSamples from the property, with the result turned into a TestResult
     (withDefault defaultNumberOfSamples p.requestedSamples) -- number of samples to generate
-    (rMap (toResult p.name) p.wrappedGenerator) -- converts each generated PartiallyAppliedPredicate into a TestResult
+    (rMap toResult p.wrappedGenerator) -- converts each generated PartiallyAppliedPredicate into a TestResult
 
 
 
@@ -368,14 +369,14 @@ printResultWith flattener (name, results) =
   let failures = filter .failed results
   in
     if length failures == 0
-    then name ++ " has passed " ++ toString (length results) ++ " tests!"
+    then toString name ++ " has passed " ++ toString (length results) ++ " tests!"
     else
       (flattener
         (map
           (\r ->
               if r.failed 
-              then r.name ++ " has failed with the following input: " ++ r.value
-              else r.name ++ " has passed with the following input: " ++ r.value)
+              then toString name ++ " has failed with the following input: " ++ r.value
+              else toString name ++ " has passed with the following input: " ++ r.value)
           failures))
 
 printSingleResult : (String, List TestResult) -> String

--- a/src/Example.elm
+++ b/src/Example.elm
@@ -18,6 +18,22 @@ prop_discontinuous : Property
 prop_discontinuous =
   property "discontinuous" (\x -> (x - 1) // (x - 1) == 1) (int 0 1000)
 
+prop_numberIsEven : Property
+prop_numberIsEven =
+  "number is even, 0 samples" `describedBy` (\n -> n % 2 == 0) `on` int 0 100 `sample` 0
+
+-- Now some pretty infix operators, just to show that it's possible.
+-- You can define your own operators of course, these are just what I
+-- came up with in one minute:
+(<:) = describedBy
+(<@) = on -- The duck head operator
+(<#>) = sample
+
+prop_01Identity : Property
+prop_01Identity =
+  "0-1 is identity on two inputs" <: (\a b -> a == b) <@ int 0 1 <@ int 0 1 <#> 2
+
+
 test : Signal TestOutput
 test =
   continuousCheck
@@ -25,6 +41,8 @@ test =
     , prop_discontinuous
     , prop_numberIsOdd
     , prop_reverseReverseList
+    , prop_numberIsEven
+    , prop_01Identity
     ]
 
 


### PR DESCRIPTION
Mostly the stuff I wrote down in the comment of the first commit.

This makes it possible to write code like

```
prop_identity_n = "Identity" `describedBy` (\x -> x == identity x) `on` int 0 1000 `sample` 200
```
instead of
```
prop_identity_n = propertyN 200 "Identity" (\x -> x == identity x) (int 0 1000) 
```

I also applied a minor change to `TestResult`, making it a single result instead of a list thereof.
Additionally, the values are now formatted as a list of strings rather than as tuples (sorry about that).

This mostly shines for properties with arity greater than 1.