### PR TITLE
Have float Investigator use the generator it builds up

### DIFF
--- a/src/Check/Investigator.elm
+++ b/src/Check/Investigator.elm
@@ -102,7 +102,7 @@ float =
           , (1, Random.float (toFloat Random.minInt) (toFloat Random.maxInt))
           ] (Random.float -50 50)
   in
-      investigator (Random.float -50 50) Shrink.float
+      investigator generator Shrink.float
 
 {-| Investigator char. Generates random ascii chars using the `ascii` generator
 from elm-random-extra and the `char` shrinker from elm-shrink. Ideal for local


### PR DESCRIPTION
The reason I messed this up with `percentage` was because I copy/pasted from `float` without noticing the same error!

This fixes `float` in the same way.