### PR TITLE
documented rangeInt

### DIFF
--- a/src/Check/Investigator.elm
+++ b/src/Check/Investigator.elm
@@ -12,7 +12,7 @@ migrating from local to cloud-based.
 @docs Investigator, investigator
 
 # Basic Investigator Generators
-@docs void, bool, order, int, float, percentage, char, ascii, unicode, string, maybe, result, list, array, tuple, tuple3, tuple4, tuple5, func, func2, func3, func4, func5
+@docs void, bool, order, int, rangeInt, float, percentage, char, ascii, unicode, string, maybe, result, list, array, tuple, tuple3, tuple4, tuple5, func, func2, func3, func4, func5
 
 -}
 import Array  exposing (Array)


### PR DESCRIPTION
Is there a reason `Check.Investigator.rangeInt` not documented? Because it's a very useful function.